### PR TITLE
Add shabang

### DIFF
--- a/buildall.sh
+++ b/buildall.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 ocamlbuild -use-menhir primify.native
 ocamlbuild -use-menhir prasm.native
 ocamlbuild -use-menhir prun.native


### PR DESCRIPTION
If running another shell then bash, eg. fish, the build process is terminated with:
Failed to execute process './buildall.sh'. Reason:
exec: Exec format error
Adding a the shabang eliminates this error.